### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 [![rime](rime-logo.png)](https://www.rime.ai)
 
-
 A Model Context Protocol (MCP) server that provides text-to-speech capabilities using the Rime API. This server downloads audio and plays it using the system's native audio player.
+
+<a href="https://glama.ai/mcp/servers/@MatthewDailey/rime-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@MatthewDailey/rime-mcp/badge" alt="Rime MCP server" />
+</a>
 
 ## Features
 


### PR DESCRIPTION
This PR adds a badge for the [Rime MCP](https://glama.ai/mcp/servers/@MatthewDailey/rime-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@MatthewDailey/rime-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@MatthewDailey/rime-mcp/badge" alt="Rime MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.